### PR TITLE
make /etc/network/if-pre-up.d/iptablesload executable

### DIFF
--- a/voodoo-vpn.sh
+++ b/voodoo-vpn.sh
@@ -125,6 +125,8 @@ echo 1 > /proc/sys/net/ipv4/ip_forward
 exit 0
 EOF
 
+chmod a+x /etc/network/if-pre-up.d/iptablesload
+
 /etc/init.d/ipsec restart
 /etc/init.d/xl2tpd restart
 


### PR DESCRIPTION
system reboot wont enable ip_forward or restore iptables unless this script is made executable
